### PR TITLE
 Fix using explicit imports.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,8 @@ docs/_build
 
 # Mypy Cache
 .mypy_cache/
+
+
+# Visual Studio Code
+.vscode/
+.vscode/*

--- a/src/comparedocs/comparator.py
+++ b/src/comparedocs/comparator.py
@@ -1,8 +1,8 @@
 import numpy as np
 from typing import Dict, List
 
-from src.comparedocs.document import Document
-from src.comparedocs.vectorizers import TfidfVectorizer, CountVectorizer
+from .document import Document
+from .vectorizers import TfidfVectorizer, CountVectorizer
 
 
 class Comparator:


### PR DESCRIPTION
Replace explicit with relative imports for importing classes to comparator.py #3 